### PR TITLE
AL/16: [hotfix] GET /fixedTermDeposit/simulate endpoint changed to POST

### DIFF
--- a/src/main/java/org/alkemy/wallet/controller/FixedTermDepositController.java
+++ b/src/main/java/org/alkemy/wallet/controller/FixedTermDepositController.java
@@ -31,7 +31,7 @@ public class FixedTermDepositController {
         return ResponseEntity.status(HttpStatus.CREATED).body(fixedTermDepositService.createDeposit(deposit));
     }
 
-    @GetMapping("/simulate")
+    @PostMapping("/simulate")
     @Operation(summary = "Simulate a term deposit",
             description = "0.5% interest rate per day.<br>" +
                     "Shows its creation and closing dates, amount invested, interest earned, total amount to collect.<br>" +

--- a/src/test/java/org/alkemy/wallet/controller/FixedTermDepositControllerTest.java
+++ b/src/test/java/org/alkemy/wallet/controller/FixedTermDepositControllerTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest(classes = WalletApplication.class)
@@ -93,7 +94,7 @@ public class FixedTermDepositControllerTest {
         fixedTermDepositSimulateDto.setClosingDate(fixedTermDepositRequestDto.getClosingDate());
         fixedTermDepositSimulateDto.setInterest(fixedTermDepositRequestDto.getAmount() * 0.05 * depositDuration);
         fixedTermDepositSimulateDto.setTotalAmount(fixedTermDepositRequestDto.getAmount() + fixedTermDepositSimulateDto.getInterest());
-        mockMvc.perform(get("/fixedDeposit/simulate").content(requestJson)
+        mockMvc.perform(post("/fixedDeposit/simulate").content(requestJson)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isOk())
@@ -109,7 +110,7 @@ public class FixedTermDepositControllerTest {
         fixedTermDepositSimulateDto.setClosingDate(fixedTermDepositRequestDto.getClosingDate());
         fixedTermDepositSimulateDto.setInterest(fixedTermDepositRequestDto.getAmount() * 0.05 * depositDuration);
         fixedTermDepositSimulateDto.setTotalAmount(fixedTermDepositRequestDto.getAmount() + fixedTermDepositSimulateDto.getInterest());
-        mockMvc.perform(get("/fixedDeposit/simulate").content(requestJson)
+        mockMvc.perform(post("/fixedDeposit/simulate").content(requestJson)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
@@ -117,7 +118,7 @@ public class FixedTermDepositControllerTest {
     }
     @Test
     void simulateFixedTermDeposit_WrongTokenProvided_UnauthorizedResponse() throws Exception {
-        mockMvc.perform(get("/fixedDeposit/simulate").
+        mockMvc.perform(post("/fixedDeposit/simulate").
                         header("Authorization", "Bearer " + userToken + "b").
                         contentType(MediaType.APPLICATION_JSON)).
                 andExpect(status().isUnauthorized());
@@ -125,7 +126,7 @@ public class FixedTermDepositControllerTest {
     @Test
     void simulateFixedTermDeposit_NoTokenProvided_UnauthorizedResponse() throws Exception{
         String requestJson = jsonMapper.writeValueAsString(fixedTermDepositRequestDto);
-        mockMvc.perform(get("/fixedDeposit/simulate").content(requestJson)
+        mockMvc.perform(post("/fixedDeposit/simulate").content(requestJson)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized());
     }
@@ -135,7 +136,7 @@ public class FixedTermDepositControllerTest {
         fixedTermDepositRequestDto.setClosingDate(cal.getTime());
         String requestJson = jsonMapper.writeValueAsString(fixedTermDepositRequestDto);
 
-        mockMvc.perform(get("/fixedDeposit/simulate").content(requestJson)
+        mockMvc.perform(post("/fixedDeposit/simulate").content(requestJson)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isBadRequest());
@@ -144,7 +145,7 @@ public class FixedTermDepositControllerTest {
     void simulateFixedTermDeposit_AmountEqual0_BadRequestResponse() throws Exception {
         fixedTermDepositRequestDto.setAmount(0.0);
         String requestJson = jsonMapper.writeValueAsString(fixedTermDepositRequestDto);
-        mockMvc.perform(get("/fixedDeposit/simulate").content(requestJson)
+        mockMvc.perform(post("/fixedDeposit/simulate").content(requestJson)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isBadRequest());


### PR DESCRIPTION
- According to OpenApi 3.0, GET is no longer allowed to have request body because it does not have defined semantics [(more info here)](https://swagger.io/docs/specification/describing-request-body/)
- Modified simulate term deposits tests as well